### PR TITLE
Step.3 あるuser_idに対して、取引を行った回数を取得する API の実装

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,20 +1,17 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
+	"log"
 	"net/http"
+
+	"github.com/taishi29/finatext-intern/internal/handler"
 )
 
 func main() {
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		response := map[string]string{"status": "ok"}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
-	})
+	// ルーティング設定（URLと関数の対応づけ）
+	http.HandleFunc("/", handler.GetTradeCountHandler)
 
-	fmt.Println("🚀 サーバー起動中 → http://localhost:8080")
-	if err := http.ListenAndServe("0.0.0.0:8080", nil); err != nil {
-		panic(err)
-	}
+	// ポート8080でHTTPサーバーを起動して、もし失敗したら（Listenできなかったら）エラーを出して終了する
+	log.Println("Listening on :8080...")
+	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/curl
+++ b/curl
@@ -1,0 +1,3 @@
+      PID    PPID    PGID     WINPID   TTY         UID    STIME COMMAND
+     1239    1190    1239      20240  cons0     197609 20:13:40 /usr/bin/PS
+     1190       1    1190      27304  cons0     197609 20:13:31 /usr/bin/bash

--- a/internal/handler/trade_count.go
+++ b/internal/handler/trade_count.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/taishi29/finatext-intern/internal/db"
+	"github.com/taishi29/finatext-intern/internal/model"
+)
+
+func GetTradeCountHandler(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(r.URL.Path, "/") // 先頭末尾の / を除去（例："A1B2C3D4E5/trades"）。
+	userID := strings.Split(path, "/")[0] // / で分割し、最初の要素を userID として取得。
+	if userID == "" {
+		http.Error(w, "ユーザーIDが指定されていません。", http.StatusBadRequest)
+		return
+	}
+
+	conn, err := db.Connect()
+	if err != nil {
+		http.Error(w, "db error", http.StatusInternalServerError)
+		return
+	}
+	defer conn.Close()
+
+	count, err := model.GetTradeCountByUserID(conn, userID)
+	if err != nil {
+		http.Error(w, "query error", http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]int{"count": count})
+}

--- a/internal/model/trade.go
+++ b/internal/model/trade.go
@@ -1,8 +1,18 @@
 package model
 
+import (
+	"database/sql"
+)
+
 type Trade struct {
 	UserID    string
 	FundID    string
 	Quantity  int
 	TradeDate string // 今は文字列。あとで time.Time にしてもOK
+}
+
+func GetTradeCountByUserID(db *sql.DB, userID string) (int, error) {
+	var count int
+	err := db.QueryRow("SELECT COUNT(*) FROM trade_history WHERE user_id = ?", userID).Scan(&count)
+	return count, err
 }


### PR DESCRIPTION
## 概要
Step.3 にて、指定した `user_id` の取引回数を取得する API エンドポイントを実装しました。  
'http://localhost:8080/A1B2C3D4E5/trades' `にアクセスすると、該当ユーザーの取引回数をJSON で返します。

## 動作確認
1. `make dev/run/import` でデータをインポート（二回以上やるとデータが重複するので、その場合はデータをクリアにしてから、再実行してください。）  
2. `make dev/run/server` でサーバーを起動  
3. 別ターミナルで以下のコマンドを実行  
   ```bash
   curl http://localhost:8080/A1B2C3D4E5/trades
   # → {"count":197} のように返ってくる