### PR TITLE
feat: マイグレーション導入と重複行を無視したCSVインポートに対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,26 @@
-APP_CONTAINER = app
+APP_CONTAINER := app
+IMPORT_ENTRYPOINT := cmd/import-csv/main.go
 
-IMPORT_ENTRYPOINT = cmd/import-csv/main.go
+.PHONY: dev/run/import dev/run/server
 
+# ──────────
+# CSV → DB 取り込み
+# (MySQL起動 → マイグレーション → CSVインポート)
+# ──────────
 dev/run/import:
-	docker compose run --rm $(APP_CONTAINER) go run $(IMPORT_ENTRYPOINT)
+	@echo "==> Booting MySQL and running migrations..."
+	docker compose up -d mysql migrate
 
+	@echo "==> Importing CSV to DB..."
+	docker compose run --rm $(APP_CONTAINER) \
+		go run $(IMPORT_ENTRYPOINT)
+
+	@echo "==> Done!"
+
+# ──────────
+# HTTP サーバー起動
+# (MySQL起動 → マイグレーション → app起動)
+# ──────────
 dev/run/server:
+	@echo "==> Starting full stack..."
 	docker compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,8 @@
 version: "3.9"
 
 services:
-  app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
-    volumes:
-      - .:/app
-    working_dir: /app
-    depends_on:
-      - mysql
-
   mysql:
     image: mysql:8.0
-    container_name: finatext-mysql
-    restart: always
-    ports:
-      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: finatext
@@ -26,6 +10,40 @@ services:
       MYSQL_PASSWORD: password
     volumes:
       - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  migrate:
+    image: migrate/migrate:v4.15.2
+    depends_on:
+      mysql:
+        condition: service_healthy
+    command:
+      [
+        "-path", "/migrations",
+        "-database", "mysql://user:password@tcp(mysql:3306)/finatext?multiStatements=true",
+        "up"
+      ]
+    volumes:
+      - ./migrations:/migrations
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      mysql:
+        condition: service_healthy
+      migrate:
+        condition: service_started
+    ports:
+      - "8080:8080"
+    volumes:
+      - .:/app
+    working_dir: /app
 
 volumes:
   mysql-data:

--- a/migrations/0001_create_tables.down.sql
+++ b/migrations/0001_create_tables.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS reference_prices;
+DROP TABLE IF EXISTS trade_history;

--- a/migrations/0001_create_tables.up.sql
+++ b/migrations/0001_create_tables.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS trade_history (
+  user_id    VARCHAR(10) NOT NULL,
+  fund_id    VARCHAR(6)  NOT NULL,
+  quantity   INT         NOT NULL,
+  trade_date DATE        NOT NULL,
+  PRIMARY KEY (user_id, fund_id, trade_date)
+);
+
+CREATE TABLE IF NOT EXISTS reference_prices (
+  fund_id              VARCHAR(6)  NOT NULL,
+  reference_price_date DATE        NOT NULL,
+  reference_price      INT         NOT NULL,
+  PRIMARY KEY (fund_id, reference_price_date)
+);


### PR DESCRIPTION
#  概要
Docker環境において、アプリケーション初期化フロー（テーブル作成 → CSVインポート → サーバー起動）を自動化しました。

##  変更内容

- マイグレーションツール migrate を導入し、テーブル定義を自動化
- migrations/*.up.sql にて trade_history, reference_prices のスキーマを定義
- `docker compose up migrate` により、自動でマイグレーションを適用
- CSVインポート処理を改善

- INSERT IGNORE を使用し、PRIMARY KEY 重複時にスキップされるよう対応

- Makefile にて healthcheck を活用し、MySQL 完全起動後にマイグレーションとインポートが実行される構成に

- `make dev/run/import`一発で全処理が完了するよう自動化`

##  動作確認
`make dev/run/import` を実行することで、以下が確認できるようになりました：
- [ ] マイグレーションによるテーブル作成
- [ ] CSV の重複行を無視したインポート
- [ ] アプリケーションからのDBアクセス成功

